### PR TITLE
bug 950945: Update for 2016

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *.sw[po]
 *.egg-info
+*.pyc

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 *.sw[po]
 *.egg-info
 *.pyc
+dist
+build

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,373 @@
+Mozilla Public License Version 2.0
+==================================
+
+1. Definitions
+--------------
+
+1.1. "Contributor"
+    means each individual or legal entity that creates, contributes to
+    the creation of, or owns Covered Software.
+
+1.2. "Contributor Version"
+    means the combination of the Contributions of others (if any) used
+    by a Contributor and that particular Contributor's Contribution.
+
+1.3. "Contribution"
+    means Covered Software of a particular Contributor.
+
+1.4. "Covered Software"
+    means Source Code Form to which the initial Contributor has attached
+    the notice in Exhibit A, the Executable Form of such Source Code
+    Form, and Modifications of such Source Code Form, in each case
+    including portions thereof.
+
+1.5. "Incompatible With Secondary Licenses"
+    means
+
+    (a) that the initial Contributor has attached the notice described
+        in Exhibit B to the Covered Software; or
+
+    (b) that the Covered Software was made available under the terms of
+        version 1.1 or earlier of the License, but not also under the
+        terms of a Secondary License.
+
+1.6. "Executable Form"
+    means any form of the work other than Source Code Form.
+
+1.7. "Larger Work"
+    means a work that combines Covered Software with other material, in 
+    a separate file or files, that is not Covered Software.
+
+1.8. "License"
+    means this document.
+
+1.9. "Licensable"
+    means having the right to grant, to the maximum extent possible,
+    whether at the time of the initial grant or subsequently, any and
+    all of the rights conveyed by this License.
+
+1.10. "Modifications"
+    means any of the following:
+
+    (a) any file in Source Code Form that results from an addition to,
+        deletion from, or modification of the contents of Covered
+        Software; or
+
+    (b) any new file in Source Code Form that contains any Covered
+        Software.
+
+1.11. "Patent Claims" of a Contributor
+    means any patent claim(s), including without limitation, method,
+    process, and apparatus claims, in any patent Licensable by such
+    Contributor that would be infringed, but for the grant of the
+    License, by the making, using, selling, offering for sale, having
+    made, import, or transfer of either its Contributions or its
+    Contributor Version.
+
+1.12. "Secondary License"
+    means either the GNU General Public License, Version 2.0, the GNU
+    Lesser General Public License, Version 2.1, the GNU Affero General
+    Public License, Version 3.0, or any later versions of those
+    licenses.
+
+1.13. "Source Code Form"
+    means the form of the work preferred for making modifications.
+
+1.14. "You" (or "Your")
+    means an individual or a legal entity exercising rights under this
+    License. For legal entities, "You" includes any entity that
+    controls, is controlled by, or is under common control with You. For
+    purposes of this definition, "control" means (a) the power, direct
+    or indirect, to cause the direction or management of such entity,
+    whether by contract or otherwise, or (b) ownership of more than
+    fifty percent (50%) of the outstanding shares or beneficial
+    ownership of such entity.
+
+2. License Grants and Conditions
+--------------------------------
+
+2.1. Grants
+
+Each Contributor hereby grants You a world-wide, royalty-free,
+non-exclusive license:
+
+(a) under intellectual property rights (other than patent or trademark)
+    Licensable by such Contributor to use, reproduce, make available,
+    modify, display, perform, distribute, and otherwise exploit its
+    Contributions, either on an unmodified basis, with Modifications, or
+    as part of a Larger Work; and
+
+(b) under Patent Claims of such Contributor to make, use, sell, offer
+    for sale, have made, import, and otherwise transfer either its
+    Contributions or its Contributor Version.
+
+2.2. Effective Date
+
+The licenses granted in Section 2.1 with respect to any Contribution
+become effective for each Contribution on the date the Contributor first
+distributes such Contribution.
+
+2.3. Limitations on Grant Scope
+
+The licenses granted in this Section 2 are the only rights granted under
+this License. No additional rights or licenses will be implied from the
+distribution or licensing of Covered Software under this License.
+Notwithstanding Section 2.1(b) above, no patent license is granted by a
+Contributor:
+
+(a) for any code that a Contributor has removed from Covered Software;
+    or
+
+(b) for infringements caused by: (i) Your and any other third party's
+    modifications of Covered Software, or (ii) the combination of its
+    Contributions with other software (except as part of its Contributor
+    Version); or
+
+(c) under Patent Claims infringed by Covered Software in the absence of
+    its Contributions.
+
+This License does not grant any rights in the trademarks, service marks,
+or logos of any Contributor (except as may be necessary to comply with
+the notice requirements in Section 3.4).
+
+2.4. Subsequent Licenses
+
+No Contributor makes additional grants as a result of Your choice to
+distribute the Covered Software under a subsequent version of this
+License (see Section 10.2) or under the terms of a Secondary License (if
+permitted under the terms of Section 3.3).
+
+2.5. Representation
+
+Each Contributor represents that the Contributor believes its
+Contributions are its original creation(s) or it has sufficient rights
+to grant the rights to its Contributions conveyed by this License.
+
+2.6. Fair Use
+
+This License is not intended to limit any rights You have under
+applicable copyright doctrines of fair use, fair dealing, or other
+equivalents.
+
+2.7. Conditions
+
+Sections 3.1, 3.2, 3.3, and 3.4 are conditions of the licenses granted
+in Section 2.1.
+
+3. Responsibilities
+-------------------
+
+3.1. Distribution of Source Form
+
+All distribution of Covered Software in Source Code Form, including any
+Modifications that You create or to which You contribute, must be under
+the terms of this License. You must inform recipients that the Source
+Code Form of the Covered Software is governed by the terms of this
+License, and how they can obtain a copy of this License. You may not
+attempt to alter or restrict the recipients' rights in the Source Code
+Form.
+
+3.2. Distribution of Executable Form
+
+If You distribute Covered Software in Executable Form then:
+
+(a) such Covered Software must also be made available in Source Code
+    Form, as described in Section 3.1, and You must inform recipients of
+    the Executable Form how they can obtain a copy of such Source Code
+    Form by reasonable means in a timely manner, at a charge no more
+    than the cost of distribution to the recipient; and
+
+(b) You may distribute such Executable Form under the terms of this
+    License, or sublicense it under different terms, provided that the
+    license for the Executable Form does not attempt to limit or alter
+    the recipients' rights in the Source Code Form under this License.
+
+3.3. Distribution of a Larger Work
+
+You may create and distribute a Larger Work under terms of Your choice,
+provided that You also comply with the requirements of this License for
+the Covered Software. If the Larger Work is a combination of Covered
+Software with a work governed by one or more Secondary Licenses, and the
+Covered Software is not Incompatible With Secondary Licenses, this
+License permits You to additionally distribute such Covered Software
+under the terms of such Secondary License(s), so that the recipient of
+the Larger Work may, at their option, further distribute the Covered
+Software under the terms of either this License or such Secondary
+License(s).
+
+3.4. Notices
+
+You may not remove or alter the substance of any license notices
+(including copyright notices, patent notices, disclaimers of warranty,
+or limitations of liability) contained within the Source Code Form of
+the Covered Software, except that You may alter any license notices to
+the extent required to remedy known factual inaccuracies.
+
+3.5. Application of Additional Terms
+
+You may choose to offer, and to charge a fee for, warranty, support,
+indemnity or liability obligations to one or more recipients of Covered
+Software. However, You may do so only on Your own behalf, and not on
+behalf of any Contributor. You must make it absolutely clear that any
+such warranty, support, indemnity, or liability obligation is offered by
+You alone, and You hereby agree to indemnify every Contributor for any
+liability incurred by such Contributor as a result of warranty, support,
+indemnity or liability terms You offer. You may include additional
+disclaimers of warranty and limitations of liability specific to any
+jurisdiction.
+
+4. Inability to Comply Due to Statute or Regulation
+---------------------------------------------------
+
+If it is impossible for You to comply with any of the terms of this
+License with respect to some or all of the Covered Software due to
+statute, judicial order, or regulation then You must: (a) comply with
+the terms of this License to the maximum extent possible; and (b)
+describe the limitations and the code they affect. Such description must
+be placed in a text file included with all distributions of the Covered
+Software under this License. Except to the extent prohibited by statute
+or regulation, such description must be sufficiently detailed for a
+recipient of ordinary skill to be able to understand it.
+
+5. Termination
+--------------
+
+5.1. The rights granted under this License will terminate automatically
+if You fail to comply with any of its terms. However, if You become
+compliant, then the rights granted under this License from a particular
+Contributor are reinstated (a) provisionally, unless and until such
+Contributor explicitly and finally terminates Your grants, and (b) on an
+ongoing basis, if such Contributor fails to notify You of the
+non-compliance by some reasonable means prior to 60 days after You have
+come back into compliance. Moreover, Your grants from a particular
+Contributor are reinstated on an ongoing basis if such Contributor
+notifies You of the non-compliance by some reasonable means, this is the
+first time You have received notice of non-compliance with this License
+from such Contributor, and You become compliant prior to 30 days after
+Your receipt of the notice.
+
+5.2. If You initiate litigation against any entity by asserting a patent
+infringement claim (excluding declaratory judgment actions,
+counter-claims, and cross-claims) alleging that a Contributor Version
+directly or indirectly infringes any patent, then the rights granted to
+You by any and all Contributors for the Covered Software under Section
+2.1 of this License shall terminate.
+
+5.3. In the event of termination under Sections 5.1 or 5.2 above, all
+end user license agreements (excluding distributors and resellers) which
+have been validly granted by You or Your distributors under this License
+prior to termination shall survive termination.
+
+************************************************************************
+*                                                                      *
+*  6. Disclaimer of Warranty                                           *
+*  -------------------------                                           *
+*                                                                      *
+*  Covered Software is provided under this License on an "as is"       *
+*  basis, without warranty of any kind, either expressed, implied, or  *
+*  statutory, including, without limitation, warranties that the       *
+*  Covered Software is free of defects, merchantable, fit for a        *
+*  particular purpose or non-infringing. The entire risk as to the     *
+*  quality and performance of the Covered Software is with You.        *
+*  Should any Covered Software prove defective in any respect, You     *
+*  (not any Contributor) assume the cost of any necessary servicing,   *
+*  repair, or correction. This disclaimer of warranty constitutes an   *
+*  essential part of this License. No use of any Covered Software is   *
+*  authorized under this License except under this disclaimer.         *
+*                                                                      *
+************************************************************************
+
+************************************************************************
+*                                                                      *
+*  7. Limitation of Liability                                          *
+*  --------------------------                                          *
+*                                                                      *
+*  Under no circumstances and under no legal theory, whether tort      *
+*  (including negligence), contract, or otherwise, shall any           *
+*  Contributor, or anyone who distributes Covered Software as          *
+*  permitted above, be liable to You for any direct, indirect,         *
+*  special, incidental, or consequential damages of any character      *
+*  including, without limitation, damages for lost profits, loss of    *
+*  goodwill, work stoppage, computer failure or malfunction, or any    *
+*  and all other commercial damages or losses, even if such party      *
+*  shall have been informed of the possibility of such damages. This   *
+*  limitation of liability shall not apply to liability for death or   *
+*  personal injury resulting from such party's negligence to the       *
+*  extent applicable law prohibits such limitation. Some               *
+*  jurisdictions do not allow the exclusion or limitation of           *
+*  incidental or consequential damages, so this exclusion and          *
+*  limitation may not apply to You.                                    *
+*                                                                      *
+************************************************************************
+
+8. Litigation
+-------------
+
+Any litigation relating to this License may be brought only in the
+courts of a jurisdiction where the defendant maintains its principal
+place of business and such litigation shall be governed by laws of that
+jurisdiction, without reference to its conflict-of-law provisions.
+Nothing in this Section shall prevent a party's ability to bring
+cross-claims or counter-claims.
+
+9. Miscellaneous
+----------------
+
+This License represents the complete agreement concerning the subject
+matter hereof. If any provision of this License is held to be
+unenforceable, such provision shall be reformed only to the extent
+necessary to make it enforceable. Any law or regulation which provides
+that the language of a contract shall be construed against the drafter
+shall not be used to construe this License against a Contributor.
+
+10. Versions of the License
+---------------------------
+
+10.1. New Versions
+
+Mozilla Foundation is the license steward. Except as provided in Section
+10.3, no one other than the license steward has the right to modify or
+publish new versions of this License. Each version will be given a
+distinguishing version number.
+
+10.2. Effect of New Versions
+
+You may distribute the Covered Software under the terms of the version
+of the License under which You originally received the Covered Software,
+or under the terms of any subsequent version published by the license
+steward.
+
+10.3. Modified Versions
+
+If you create software not governed by this License, and you want to
+create a new license for such software, you may create and use a
+modified version of this License if you rename the license and remove
+any references to the name of the license steward (except to note that
+such modified license differs from this License).
+
+10.4. Distributing Source Code Form that is Incompatible With Secondary
+Licenses
+
+If You choose to distribute Source Code Form that is Incompatible With
+Secondary Licenses under the terms of this version of the License, the
+notice described in Exhibit B of this License must be attached.
+
+Exhibit A - Source Code Form License Notice
+-------------------------------------------
+
+  This Source Code Form is subject to the terms of the Mozilla Public
+  License, v. 2.0. If a copy of the MPL was not distributed with this
+  file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+If it is not possible or desirable to put the notice in a particular
+file, then You may include the notice in a location (such as a LICENSE
+file in a relevant directory) where a recipient would be likely to look
+for such a notice.
+
+You may add additional accurate notices of copyright ownership.
+
+Exhibit B - "Incompatible With Secondary Licenses" Notice
+---------------------------------------------------------
+
+  This Source Code Form is "Incompatible With Secondary Licenses", as
+  defined by the Mozilla Public License, v. 2.0.

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,7 @@
-include README.rst mdn_theme/mdn/layout.html mdn_theme/mdn/theme.conf
+exclude Makefile
+exclude requirements.txt
+include LICENSE
+include README.rst
+include mdn_theme/mdn/layout.html
+include mdn_theme/mdn/theme.conf
 recursive-include mdn_theme/mdn/static *

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,30 @@
+.PHONY: help clean clean-pyc clean-build docs docs-fresh
+
+help:
+	@echo "clean - remove build artifacts"
+	@echo "sdist - package"
+	@echo "test-release - package and upload a release to the test PyPI server"
+	@echo "release - package and upload a release"
+
+clean:
+	rm -fr build/
+	rm -fr dist/
+	rm -fr *.egg-info
+	find . -name '*.pyc' -exec rm -f {} +
+	find . -name '*.pyo' -exec rm -f {} +
+	find . -name '*~' -exec rm -f {} +
+
+sdist: clean
+	python setup.py sdist
+	ls -l dist
+	check-manifest
+	pyroma dist/`ls -t dist | head -n1`
+
+test-release: sdist
+	python setup.py register -r https://testpypi.python.org/pypi
+	python setup.py sdist bdist_wheel upload -r https://testpypi.python.org/pypi
+	python -m webbrowser -n https://testpypi.python.org/pypi/mdn-sphinx-theme
+
+release: sdist
+	python setup.py sdist bdist_wheel upload
+	python -m webbrowser -n https://pypi.python.org/pypi/mdn-sphinx-theme

--- a/README.rst
+++ b/README.rst
@@ -1,8 +1,9 @@
-Mozilla Developer Network Sphinx theme
+Mozilla Developer Network Sphinx Theme
 ======================================
 
 This is a version of the Mozilla Developer Network theme, for
-`the Sphinx documentation engine. <http://sphinx.pocoo.org>`_.
+the `Sphinx documentation engine`_. It is used for the
+`Kuma development documentation`_.
 
 Here is how I use it
 --------------------
@@ -34,3 +35,6 @@ packages listed there::
 
 Then configure your Readthedocs project to use that requirement file
 before rendering your project's documentation.
+
+.. _`Sphinx documentation engine`: http://www.sphinx-doc.org/en/stable/
+.. _`Kuma development documentation`: https://kuma.readthedocs.io/en/latest/

--- a/mdn_theme/__init__.py
+++ b/mdn_theme/__init__.py
@@ -1,6 +1,6 @@
 import os
 
-__version__ = '2015.2'
+__version__ = '2016.0'
 
 here = os.path.dirname(__file__)
 

--- a/mdn_theme/__init__.py
+++ b/mdn_theme/__init__.py
@@ -4,5 +4,6 @@ __version__ = '2015.2'
 
 here = os.path.dirname(__file__)
 
+
 def get_theme_dir():
     return here

--- a/mdn_theme/mdn/layout.html
+++ b/mdn_theme/mdn/layout.html
@@ -1,56 +1,56 @@
-<!DOCTYPE html><html class="redesign no-js" dir="ltr" lang="en-US"><head prefix="og: http://ogp.me/ns#">
+<!DOCTYPE html>
+<html data-ffo-opensanslight="false" data-ffo-opensans="false" lang="en-US" dir="ltr" class="redesign no-js"><head>
   <meta charset="utf-8">
   <meta content="IE=Edge" http-equiv="X-UA-Compatible">
   <script>(function(d) { d.className = d.className.replace(/\bno-js/, ''); })(document.documentElement);</script>
-    <title>{{ docstitle|e }} &amp;mdash; MDN</title>
+  
+  <title>{{ docstitle }} - MDN</title>
 
   <meta content="width=device-width, initial-scale=1" name="viewport">
   <meta content="index, follow" name="robots">
-  <link href="https://developer.mozilla.org/" rel="home"></link>
-  <link href="https://developer.mozilla.org/#copyright" rel="copyright"></link>
 
-      <link href="https://developer.mozilla.org/static/styles/font-awesome.css" media="all" rel="stylesheet"></link>
-<link href="https://developer.mozilla.org/static/styles/main.css" media="all" rel="stylesheet"></link>
+  
+    <link type="text/css" href="https://developer.mozilla.org/static/build/styles/mdn.65be1fdadb40.css" rel="stylesheet"></link>
 
-  <!-- common social tags -->
-    <meta content="website" property="og:type">
-  <meta content="http://testserver/static/img/opengraph-logo.png" property="og:image">
-  <meta content="Mozilla Developer Network" property="og:site_name">
-  <meta content="summary" name="twitter:card">
-  <meta content="http://testserver/static/img/opengraph-logo.png" name="twitter:image">
-  <meta content="@NewOnMDN" name="twitter:site">
-  <meta content="@NewOnMDN" name="twitter:creator">
-
-  <link href="https://developer-local.allizom.org/en-US/search/xml" rel="search" title="Mozilla Developer Network" type="application/opensearchdescription+xml"></link>
+    
+  
 
   <!-- third-generation iPad with high-resolution Retina display: -->
-  <link href="https://developer.mozilla.org/static/img/favicon144.png" rel="apple-touch-icon-precomposed" sizes="144x144"></link>
+  <link href="https://developer.mozilla.org/static/img/favicon144.a6e4162070f4.png" rel="apple-touch-icon-precomposed" sizes="144x144"></link>
   <!-- iPhone with high-resolution Retina display: -->
-  <link href="https://developer.mozilla.org/static/img/favicon114.png" rel="apple-touch-icon-precomposed" sizes="114x114"></link>
+  <link href="https://developer.mozilla.org/static/img/favicon114.0e9fabd44f85.png" rel="apple-touch-icon-precomposed" sizes="114x114"></link>
   <!-- first- and second-generation iPad: -->
-  <link href="https://developer.mozilla.org/static/img/favicon72.png" rel="apple-touch-icon-precomposed" sizes="72x72"></link>
+  <link href="https://developer.mozilla.org/static/img/favicon72.8ff9d87c82a0.png" rel="apple-touch-icon-precomposed" sizes="72x72"></link>
   <!-- non-Retina iPhone, iPod Touch, and Android 2.1+ devices: -->
-  <link href="https://developer.mozilla.org/static/img/favicon57.png" rel="apple-touch-icon-precomposed"></link>
+  <link href="https://developer.mozilla.org/static/img/favicon57.a2490b9a2d76.png" rel="apple-touch-icon-precomposed"></link>
   <!-- basic favicon -->
-          <link href="https://developer.mozilla.org/static/img/favicon32-local.png" rel="shortcut icon"></link>
+  
+    
+  
+  <link href="https://developer.mozilla.org/static/img/favicon32.e02854fdcf73.png" rel="shortcut icon"></link>
   <!--[if IE]>
   <meta http-equiv="imagetoolbar" content="no">
-  <script src="/static/js/libs/html5.js"></script>
+  <script type="text/javascript" src="https://developer.mozilla.org/static/build/js/html5shiv.3948ccddab6f.js" charset="utf-8"></script>
   <![endif]-->
 
-    <link href="https://developer.mozilla.org/static/styles/wiki.css" media="screen,projection,tv" rel="stylesheet"></link>
-<link href="https://developer.mozilla.org/static/styles/sphinx.css" media="screen,projection,tv" rel="stylesheet"></link>
+  <link type="text/css" href="https://developer.mozilla.org/static/build/styles/sphinx.6b9e59817919.css" rel="stylesheet"></link>
 
-  </head>
+
+  
+</head>
 <body class="">
 
   <script type="text/javascript">
     (function(win) {
         'use strict';
 
+        
+
+        // This needs to be set before ckeditor.js loads
+        window.CKEDITOR_BASEPATH = '/static/js/libs/ckeditor/build/ckeditor/';
+
         // This represents the site configuration
         win.mdn = {
-            build: 'dev',
             // Properties and settings for CKEditor will go here
             ckeditor: {},
             // Feature test results and methods will be placed here
@@ -60,25 +60,35 @@
             // Optimizely API
             optimizely: win['optimizely'] || [],
             // Site notifications
-                        notifications: [],
-                        // Wiki-specific settings will be placed here
+            
+            notifications: [],
+            
+            // Wiki-specific settings will be placed here
             wiki: {
                 autosuggestTitleUrl: '/docs/get-documents'
             },
-            searchFilters: [{"name": "Document type", "slug": "type", "order": 1, "filters": [{"name": "Tools", "slug": "tools", "shortcut": null}, {"name": "Code Samples", "slug": "code", "shortcut": null}, {"name": "How-To & Tutorial", "slug": "howto", "shortcut": null}]}, {"name": "Skill level", "slug": "skill", "order": 1, "filters": [{"name": "I'm an Expert", "slug": "advanced", "shortcut": null}, {"name": "Intermediate", "slug": "intermediate", "shortcut": null}, {"name": "I'm Learning", "slug": "beginner", "shortcut": null}]}, {"name": "Topics", "slug": "topic", "order": 1, "filters": [{"name": "Open Web Apps", "slug": "apps", "shortcut": null}, {"name": "HTML", "slug": "html", "shortcut": null}, {"name": "CSS", "slug": "css", "shortcut": null}, {"name": "JavaScript", "slug": "js", "shortcut": null}, {"name": "APIs and DOM", "slug": "api", "shortcut": null}, {"name": "Canvas", "slug": "canvas", "shortcut": null}, {"name": "SVG", "slug": "svg", "shortcut": null}, {"name": "MathML", "slug": "mathml", "shortcut": null}, {"name": "WebGL", "slug": "webgl", "shortcut": null}, {"name": "XUL", "slug": "xul", "shortcut": null}, {"name": "Marketplace", "slug": "marketplace", "shortcut": null}, {"name": "Firefox", "slug": "firefox", "shortcut": null}, {"name": "Firefox for Android", "slug": "firefox-mobile", "shortcut": null}, {"name": "Firefox for Desktop", "slug": "firefox-desktop", "shortcut": null}, {"name": "Firefox OS", "slug": "firefox-os", "shortcut": null}, {"name": "Mobile", "slug": "mobile", "shortcut": null}, {"name": "Web Development", "slug": "webdev", "shortcut": null}, {"name": "Add-ons & Extensions", "slug": "addons", "shortcut": null}, {"name": "Games", "slug": "games", "shortcut": null}]}]
+            // Assets that need to be dynamically injected
+            assets: {
+                css: {
+                    'editor-content': ['/static/build/styles/editor-content.cdc2a41387bb.css',],
+                    'wiki-compat-tables': ['/static/build/styles/wiki-compat-tables.f3a3bfce97a1.css',]
+                },
+                js: {
+                    'syntax-prism': ['/static/build/js/syntax-prism.7a66ddfa68bf.js',],
+                    'wiki-compat-tables': ['/static/build/js/wiki-compat-tables.14ce5dcb2c3d.js',]
+                }
+            }
         };
-
-        // Ensures gettext always returns something, is always set
-        win.gettext = function(x) {
-            return x;
-        }
-    })(window);
+    })(this);
 </script>
+
+  
+
+  
 
   <ul id="nav-access">
     <li><a href="https://developer.mozilla.org/#content" id="skip-main">Skip to main content</a></li>
-    <li><a href="https://developer.mozilla.org/#language" id="skip-language">Select language</a></li>
-      </ul>
+  </ul>
 
   <!-- Header -->
   <header id="main-header"><div class="center">
@@ -89,76 +99,100 @@
 
     <div class="clear header-clear"></div>
 
-    <a class="logo" href="https://developer.mozilla.org/">Mozilla Developer Network</a>
 
-    <div class="header-login">
-            </div>
+    <a href="https://developer.mozilla.org/" class="logo">Mozilla Developer Network</a>
 
-    <nav id="main-nav" role="navigation"><ul><li><a href="https://developer.mozilla.org/en-US/docs/Zones">Zones<i aria-hidden="true" class="icon-caret-down"></i></a>
 
-        <div class="submenu submenu-single" id="nav-zones-submenu">
-          <div class="submenu-column">
-            <ul>
-              <li><a href="https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons">Add-ons</a></li>
-              <li><a href="https://developer.mozilla.org/en-US/docs/Apps">App Center</a></li>
-              <li><a href="https://developer.mozilla.org/en-US/docs/Firefox">Firefox</a></li>
-              <li><a href="https://developer.mozilla.org/en-US/docs/Mozilla/Marketplace">Firefox Marketplace</a></li>
-              <li><a href="https://developer.mozilla.org/en-US/docs/Firefox_OS">Firefox OS</a></li>
-              <li><a href="https://developer.mozilla.org/en-US/docs/Persona">Persona</a></li>
-            </ul>
-          </div>
-        </div>
-      </li><li><a href="https://developer.mozilla.org/en-US/docs/Web">Web Platform<i aria-hidden="true" class="icon-caret-down"></i></a>
+    <div id="nav-sec">
+        
+    </div>
 
-        <div class="submenu" id="nav-platform-submenu">
+    <nav role="navigation" id="main-nav"><ul><li><a href="https://developer.mozilla.org/docs/Web">Web Platform<i class="icon-caret-down" aria-hidden="true"></i></a>
+
+        <div id="nav-platform-submenu" class="submenu submenu-cols-2 js-submenu">
           <div class="submenu-column">
             <div class="title">Technologies</div>
             <ul>
-              <li><a href="https://developer.mozilla.org/en-US/docs/Web/HTML">HTML</a></li>
-              <li><a href="https://developer.mozilla.org/en-US/docs/Web/CSS">CSS</a></li>
-              <li><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript">JavaScript</a></li>
-              <li><a href="https://developer.mozilla.org/en-US/docs/Web/Guide/Graphics">Graphics</a></li>
-              <li><a href="https://developer.mozilla.org/en-US/docs/Web/API">APIs / DOM</a></li>
-              <li><a href="https://developer.mozilla.org/en-US/docs/Web/Apps">Apps</a></li>
-              <li><a href="https://developer.mozilla.org/en-US/docs/Web/MathML">MathML</a></li>
+              <li><a href="https://developer.mozilla.org/docs/Web/HTML">HTML</a></li>
+              <li><a href="https://developer.mozilla.org/docs/Web/CSS">CSS</a></li>
+              <li><a href="https://developer.mozilla.org/docs/Web/JavaScript">JavaScript</a></li>
+              <li><a href="https://developer.mozilla.org/docs/Web/Guide/Graphics">Graphics</a></li>
+              <li><a href="https://developer.mozilla.org/docs/Web/HTTP">HTTP</a></li>
+              <li><a href="https://developer.mozilla.org/docs/Web/API">APIs / DOM</a></li>
+              <li><a href="https://developer.mozilla.org/docs/Web/Apps">Apps</a></li>
+              <li><a href="https://developer.mozilla.org/docs/Web/MathML">MathML</a></li>
             </ul>
           </div><div class="submenu-column last">
             <div class="title">References &amp; Guides</div>
             <ul>
-              <li><a href="https://developer.mozilla.org/en-US/docs/Web/Tutorials">Tutorials</a></li>
-              <li><a href="https://developer.mozilla.org/en-US/docs/Web/Reference">References</a></li>
-              <li><a href="https://developer.mozilla.org/en-US/docs/Web/Guide">Developer Guides</a></li>
-              <li><a href="https://developer.mozilla.org/en-US/docs/Web/Accessibility">Accessibility</a></li>
-              <li><a href="https://developer.mozilla.org/demos/">Demos</a></li>
-              <li><a href="https://developer.mozilla.org/en-US/docs/Web">...more docs</a></li>
+              <li><a href="https://developer.mozilla.org/docs/Learn">Learn the Web</a></li>
+              <li><a href="https://developer.mozilla.org/docs/Web/Tutorials">Tutorials</a></li>
+              <li><a href="https://developer.mozilla.org/docs/Web/Reference">References</a></li>
+              <li><a href="https://developer.mozilla.org/docs/Web/Guide">Developer Guides</a></li>
+              <li><a href="https://developer.mozilla.org/docs/Web/Accessibility">Accessibility</a></li>
+              <li><a href="https://developer.mozilla.org/docs/Games">Game development</a></li>
+              <li><a href="https://developer.mozilla.org/docs/Web">...more docs</a></li>
             </ul>
           </div>
         </div>
-      </li><li><a href="https://developer.mozilla.org/en-US/docs/Tools">Tools</a></li><li><a href="https://developer.mozilla.org/demos/">Demos</a></li><li><a href="https://developer.mozilla.org/en-US/docs/Mozilla/Connect">Connect</a></li><li class="nav-search-link"><a href="https://developer.mozilla.org/search" title="Search"><i aria-hidden="true" class="icon-search"></i></a></li></ul></nav>
+      </li><li><a href="https://developer.mozilla.org/docs/Zones">Mozilla Docs<i class="icon-caret-down" aria-hidden="true"></i></a>
+
+        <div id="nav-zones-submenu" class="submenu js-submenu">
+          <div class="submenu-column">
+            <ul>
+              <li><a href="https://developer.mozilla.org/docs/Mozilla/Add-ons">Add-ons</a></li>
+              <li><a href="https://developer.mozilla.org/docs/Mozilla/Firefox">Firefox</a></li>
+              <li><a href="https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions">WebExtensions</a></li>
+            </ul>
+          </div>
+        </div>
+      </li><li><a href="https://developer.mozilla.org/docs/Tools">Developer Tools</a></li><li><a href="https://developer.mozilla.org/docs/MDN/Feedback">Feedback<i class="icon-caret-down" aria-hidden="true"></i></a>
+
+        <div id="nav-contact-submenu" class="submenu js-submenu">
+          <div class="submenu-column">
+            <ul>
+                <li><a href="https://support.mozilla.org/">Get Firefox help<i class="icon-external-link" aria-hidden="true"></i></a></li>
+                <li><a href="http://stackoverflow.com/">Get web development help<i class="icon-external-link" aria-hidden="true"></i></a></li>
+            </ul>
+            <ul>
+              <li><a href="https://developer.mozilla.org/docs/MDN/Community">Join the MDN community</a></li>
+              <li><a href="https://bugzilla.mozilla.org/form.doc?bug_file_loc=http%3A//developer.mozilla.org/">Report a content problem<i class="icon-external-link" aria-hidden="true"></i></a></li>
+              <li><a href="https://bugzilla.mozilla.org/form.mdn">Report a bug<i class="icon-external-link" aria-hidden="true"></i></a></li>
+            </ul>
+          </div>
+        </div>
+
+      </li><li class="nav-search-link"><a href="https://developer.mozilla.org/search" title="Search"><i class="icon-search" aria-hidden="true"></i></a></li></ul></nav>
   </div></header>
 
   <!-- Content will go here -->
   <main id="content"><div class="center clear">
-
-    <!-- left crumb navigation -->
-    <nav class="crumbs" role="navigation"><ol><li class="crumb"><a href="{{ pathto(master_doc) }}">{{ docstitle }}</a></li><li class="crumb">{{ title }}</li></ol></nav>
-
-  <div id="wiki-column-container">
-    <div class="column-container column-container-reverse">
-      <div class="column-strip wiki-column" id="wiki-right">
-        <!-- table of contents -->
-        <div class="toc toggleable" id="toc">
-          <a class="title toggler" href="https://developer.mozilla.org/#toc">Table of Contents<i></i></a>
-          <ol class="toggle-container">
-            {{ toctree(collapse=False) }}
-          </ol>
+  
+  <!-- left crumb navigation -->
+  <nav role="navigation" class="crumbs">
+    <ol>
+      <li class="crumb"><a href="{{ pathto(master_doc) }}">{{ docstitle }}</a></li>
+      <li class="crumb">{{ title }}</li>
+    </ol>
+  </nav>
+  <div class="page-buttons hidden"></div>
+  <div class="wiki-main-content"><div class="center">
+    <div id="wiki-column-container">
+      <div class="column-container column-container-reverse">
+        <div id="wiki-right" class="column-strip wiki-column">
+          <div class="toc toggleable" id="toc">
+            <a href="https://developer.mozilla.org/#toc" class="title toggler">Table of Contents<i></i></a>
+            <ol class="toggle-container">
+              {{ toctree(collapse=False) }}
+            </ol>
+          </div>
+        </div>
+        <div class="column-main wiki-column text-content" id="wiki-content">
+          {% block body %}{% endblock %}
         </div>
       </div>
-      <div class="column-main wiki-column text-content" id="wiki-content">
-           {% block body %}{% endblock %}
-      </div>
     </div>
-  </div>
+  </div></div>
 
   </div></main>
 
@@ -166,32 +200,38 @@
   <footer><div class="center">
     <div class="column-container">
       <div class="column-main">
-            <p>
-      © 2005-2015 Mozilla Developer Network and individual contributors<br> Content is available under a license specific to this project. · <a href="https://developer.mozilla.org/en-US/docs/Project:About">About MDN</a> · <a href="//github.com/mozilla/kuma">Contribute to the code</a> · <a href="//www.mozilla.org/en-US/privacy">Privacy policy</a>    </p>
+        
+  <p>
+    © 2005-2016 Mozilla Developer Network and individual contributors<br> Content is available under a license specific to this project. · <a href="https://developer.mozilla.org/docs/Project:About">About MDN</a> · <a href="//github.com/mozilla/kuma">Contribute to the code</a> · <a href="//www.mozilla.org/en-US/privacy">Privacy policy</a>
+  </p>
+
+        </div>
       </div>
       <div class="column-strip">
-              </div>
+        
+      </div>
     </div>
-  </div></footer>
+  </footer>
 
   <!-- site js -->
-    <!--[if lte IE 8]><script src="/static/js/libs/selectivizr-1.0.2/selectivizr-build.js"></script><![endif]-->
+  
+    <!--[if lte IE 8]><script type="text/javascript" src="https://developer.mozilla.org/static/build/js/selectivizr.091e18cf669b.js" charset="utf-8"></script><![endif]-->
 
-    <script src="https://login.persona.org/include.js"></script>
-<form action="https://developer.mozilla.org/users/persona/signin" data-csrf-token-url="/users/persona/csrf" data-request='{"siteName": "Mozilla Developer Network", "siteLogo": "/static/img/opengraph-logo.png"}' id="_persona_login" method="post">
-  <input id="_persona_csrf_token" name="csrfmiddlewaretoken" type="hidden" value="">
-  <input id="_persona_next_url" name="next" type="hidden" value="">
-  <input id="_persona_process" name="process" type="hidden" value="">
-  <input id="_persona_assertion" name="assertion" type="hidden">
+    <form data-csrf-token-url="/users/persona/csrf" data-persona-script="https://login.persona.org/include.js" method="post" data-request='{"siteName": "Mozilla Developer Network", "siteLogo": "/static/img/opengraph-logo.png"}' id="_persona_login" action="https://developer.mozilla.org/users/persona/signin">
+  <input type="hidden" id="_persona_csrf_token" value="" name="csrfmiddlewaretoken">
+  <input type="hidden" id="_persona_next_url" value="" name="next">
+  <input type="hidden" id="_persona_process" value="" name="process">
+  <input type="hidden" id="_persona_assertion" name="assertion">
+</form>
 
 
-<script src="https://developer.mozilla.org/static/js/libs/jquery-2.1.0.js"></script>
-<script src="https://developer.mozilla.org/static/js/components.js"></script>
-<script src="https://developer.mozilla.org/static/js/analytics.js"></script>
-<script src="https://developer.mozilla.org/static/js/main.js"></script>
-<script src="https://developer.mozilla.org/static/js/auth.js"></script>
-<script src="https://developer.mozilla.org/static/js/badges.js"></script>
-<script src="https://developer.mozilla.org/static/js/search-navigator.js"></script>
-<script src="https://developer.mozilla.org/static/js/wiki.js"></script>
+    <script type="text/javascript" charset="utf-8" src="https://developer.mozilla.org/static/build/js/main.a7b27a25fb9c.js"></script>
+    
+    
+    <script type="text/javascript" src="https://developer.mozilla.org/static/jsi18n/en-us/javascript.b28203373cc1.js"></script>
+  
 
-</form></body></html>
+  <script type="text/javascript" charset="utf-8" src="https://developer.mozilla.org/static/build/js/wiki.eecc8b9caafa.js" async></script>
+
+
+</body></html>

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,6 @@
+# Quality checks for the distribution files
+check-manifest==0.33
+pyroma==2.0.2
+
+# Build a wheel
+wheel==0.24.0

--- a/setup.py
+++ b/setup.py
@@ -28,4 +28,16 @@ setup(
     zip_safe=False,
     include_package_data=True,
     install_requires=['sphinx'],
+    url='https://github.com/mdn/sphinx-theme',
+    license='MPL 2.0',
+    keywords='sphinx extension theme mdn',
+    classifiers=[
+        'Development Status :: 5 - Production/Stable',
+        'Intended Audience :: Developers',
+        'License :: OSI Approved :: Mozilla Public License 2.0 (MPL 2.0)',
+        'Operating System :: OS Independent',
+        'Programming Language :: Python :: 2.7',
+        'Topic :: Documentation',
+        'Topic :: Software Development :: Documentation',
+    ]
 )


### PR DESCRIPTION
This makes several updates to the theme for the 2016.0 release:
- Synchronize the template with MDN's current style and assets, fixing bugs #5 and #7
- Add a `Makefile` to automate package linting and the release process
- Update the package with classifiers, a homepage, etc.
- Add a MPL 2.0 license to the project
