### PR TITLE
Deprecate project

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,17 +1,12 @@
 Mozilla Developer Network Sphinx Theme
 ======================================
 
-**Note:** This theme was used on MDN from 2013 to 2017. It broke with the
-move of MDN to AWS on Oct 10th, 2017. [Kuma](https://github.com/mozilla/kuma)
-is no longer using it for its
-[documentation](https://kuma.readthedocs.io/en/latest/), and we don't plan to
-update the the theme. See
-[bug 1361729](https://bugzilla.mozilla.org/show_bug.cgi?id=1361729) for
-details.
+**Warning:** *This theme is broken, and won't be fixed. For details, see:*
+`bug 1361729`_
 
 This is a version of the Mozilla Developer Network theme, for
-the `Sphinx documentation engine`_. It is used for the
-`Kuma development documentation`_.
+the `Sphinx documentation engine`_. It was used for the
+Kuma development documentation.
 
 Here is how I use it
 --------------------
@@ -45,4 +40,5 @@ Then configure your Readthedocs project to use that requirement file
 before rendering your project's documentation.
 
 .. _`Sphinx documentation engine`: http://www.sphinx-doc.org/en/stable/
-.. _`Kuma development documentation`: https://kuma.readthedocs.io/en/latest/
+.. _`bug 1361729`: https://bugzilla.mozilla.org/show_bug.cgi?id=1361729
+

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ setup(
     license='MPL 2.0',
     keywords='sphinx extension theme mdn',
     classifiers=[
-        'Development Status :: 5 - Production/Stable',
+        'Development Status :: 7 - Inactive',
         'Intended Audience :: Developers',
         'License :: OSI Approved :: Mozilla Public License 2.0 (MPL 2.0)',
         'Operating System :: OS Independent',


### PR DESCRIPTION
As predicted in [bug 1361729](https://bugzilla.mozilla.org/show_bug.cgi?id=1361729), the move from SCL3 to AWS has broken the sphinx-theme.  We're taking the opportunity to switch Kuma docs [to the well-supported Alabaster theme](https://github.com/mozilla/kuma/pull/4457), and deprecate this theme.